### PR TITLE
Avoid returning nil values from `ClassDeclaration#child_nodes`

### DIFF
--- a/lib/syntax_tree.rb
+++ b/lib/syntax_tree.rb
@@ -3698,7 +3698,11 @@ class SyntaxTree < Ripper
     end
 
     def child_nodes
-      [constant, superclass, bodystmt]
+      [].tap do |nodes|
+        nodes << constant
+        nodes << superclass if superclass
+        nodes << bodystmt
+      end
     end
 
     def format(q)


### PR DESCRIPTION
For a class declaration node having `superclass ` is optional so currently `ClassDeclaration#child_nodes` method returns an array that contains a `nil` value which complicates traversing a little bit.
Here is an example:
```ruby
SyntaxTree.parse("class A;end").child_nodes.first.body.first.child_nodes.map(&:class)
 => [SyntaxTree::ConstRef, NilClass, SyntaxTree::BodyStmt] 
```

I wasn't sure about our intentions, but I feel like it might be helpful to expect `child_nodes` to always return an array of node objects and nothing else so I opened this PR as a discussion with a potential solution.

The solution I'm suggesting may look excessive but I end up choosing it versus calling `.compact` on the resulting array because I liked that we explicitly state which part of the class declaration is optional. Let me know if you have other suggestions!

After the change:
```ruby
3.0.3 :014 > SyntaxTree.parse("class A;end").child_nodes.first.body.first.child_nodes.map(&:class)
 => [SyntaxTree::ConstRef, SyntaxTree::BodyStmt] 
```

If we think that this is a reasonable change to implement, I can quickly change similar nodes like `BodyStmt`, for example:
https://github.com/kddnewton/syntax_tree/blob/d738840feab02648899f08d00dc9fcf5f018f6a3/lib/syntax_tree.rb#L2850

I haven't covered it with tests because wasn't sure if that would be a correct change to do so let me know if I should add some.

Thanks!


